### PR TITLE
Remove incorrect trailing spaces from P2 test 09 output

### DIFF
--- a/p2/README.md
+++ b/p2/README.md
@@ -5,6 +5,7 @@
 ## LOG alterações
 
 - 7mai21 - Publicação do enunciado.
+- 17mai21 - Atualização teste 09.
 
 ## 1. Introdução
 

--- a/p2/tests/test09.out
+++ b/p2/tests/test09.out
@@ -4,7 +4,7 @@
 /70M/adS/ypl/iQQ DT_
 /70M/adS/ypl/Ukn 6^b
 /70M/adS/ypl/ptU wNR
-/70M/adS/7TG EF 
+/70M/adS/7TG EF
 /70M/adS/7TG/IL3 #p@
 /70M/adS/7TG/XyG H&*
 /70M/adS/7TG/Rvr ~w|
@@ -87,7 +87,7 @@
 /zgN/HJf/wFU tnt
 /zgN/HJf/wFU/q_q &zf
 /zgN/HJf/wFU/wbK w|+
-/zgN/HJf/wFU/4P8 wq 
+/zgN/HJf/wFU/4P8 wq
 /zgN/HJf/dzx ~,<
 /zgN/HJf/dzx/8V2 }/z
 /zgN/HJf/dzx/xgo XY3


### PR DESCRIPTION
De acordo com o enunciado,
> No entanto, o último argumento pode conter espaços ou tabuladores se for um `<valor>`,
sendo que um `<valor>` não tem espaços ou tabuladores no início ou no **fim**.

Neste teste, duas das linhas tinham um espaço no final, o que vai contra o que está dito no enunciado, pois o `<valor>` não deverá conter espaços/tabuladores no início ou fim.

O comando `set` tem o formato de entrada `set <caminho> <valor>`, ou seja, o seu último argumento é um `<valor>`, não devendo conter assim espaços no início ou fim.  
Do mesmo modo, o comando `print` tem o formato de saída `<caminho> <valor>`, também tendo o último argumento `<valor>`, e então nunca deverá acabar com um espaço.